### PR TITLE
Adding more APIs to gcp ipranges clients

### DIFF
--- a/components/kcp/pkg/provider/gcp/client/gcpConstants.go
+++ b/components/kcp/pkg/provider/gcp/client/gcpConstants.go
@@ -6,6 +6,7 @@ import (
 
 const vPCPathPattern = "projects/%s/global/networks/%s"
 const ServiceNetworkingServicePath = "services/servicenetworking.googleapis.com"
+const ServiceNetworkingServiceConnectionName = "services/servicenetworking.googleapis.com/connections/servicenetworking-googleapis-com"
 
 func GetVPCPath(projectId, vpcId string) string {
 	return fmt.Sprintf(vPCPathPattern, projectId, vpcId)

--- a/components/kcp/pkg/provider/gcp/iprange/client/computeClient.go
+++ b/components/kcp/pkg/provider/gcp/iprange/client/computeClient.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/kyma-project/cloud-manager/components/kcp/pkg/provider/gcp/client"
 	gcpclient "github.com/kyma-project/cloud-manager/components/kcp/pkg/provider/gcp/client"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/option"
@@ -13,6 +12,8 @@ import (
 type ComputeClient interface {
 	ListGlobalAddresses(ctx context.Context, projectId, vpc string) (*compute.AddressList, error)
 	CreatePscIpRange(ctx context.Context, projectId, name, description, address string, prefixLength int64) (*compute.Operation, error)
+	DeleteIpRange(ctx context.Context, projectId, name string) (*compute.Operation, error)
+	GetIpRange(ctx context.Context, projectId, name string) (*compute.Address, error)
 }
 
 func NewComputeClient() gcpclient.ClientProvider[ComputeClient] {
@@ -35,21 +36,28 @@ type computeClient struct {
 	svcCompute *compute.Service
 }
 
-// CreatePscIpRange implements ComputeClient.
+func (c *computeClient) GetIpRange(ctx context.Context, projectId, name string) (*compute.Address, error) {
+	return c.svcCompute.GlobalAddresses.Get(projectId, name).Do()
+}
+
+func (c *computeClient) DeleteIpRange(ctx context.Context, projectId, name string) (*compute.Operation, error) {
+	return c.svcCompute.GlobalAddresses.Delete(projectId, name).Do()
+}
+
 func (c *computeClient) CreatePscIpRange(ctx context.Context, projectId, name, description, address string, prefixLength int64) (*compute.Operation, error) {
 	return c.svcCompute.GlobalAddresses.Insert(projectId, &compute.Address{
 		Name:         name,
 		Description:  description,
 		Address:      address,
 		PrefixLength: prefixLength,
-		NetworkTier:  string(client.NetworkTierPremium),
-		AddressType:  string(client.AddressTypeInternal),
-		Purpose:      string(client.IpRangePurposeVPCPeering),
+		NetworkTier:  string(gcpclient.NetworkTierPremium),
+		AddressType:  string(gcpclient.AddressTypeInternal),
+		Purpose:      string(gcpclient.IpRangePurposeVPCPeering),
 	}).Do()
 }
 
 func (c *computeClient) ListGlobalAddresses(ctx context.Context, projectId, vpc string) (*compute.AddressList, error) {
-	filter := fmt.Sprintf("network=\"%s\"", client.GetVPCPath(projectId, vpc))
+	filter := fmt.Sprintf("network=\"%s\"", gcpclient.GetVPCPath(projectId, vpc))
 	out, err := c.svcCompute.GlobalAddresses.List(projectId).Filter(filter).Do()
 	if err != nil {
 		return nil, err

--- a/components/kcp/pkg/provider/gcp/iprange/client/serviceNetworkingClient.go
+++ b/components/kcp/pkg/provider/gcp/iprange/client/serviceNetworkingClient.go
@@ -10,7 +10,9 @@ import (
 
 type ServiceNetworkingClient interface {
 	ListServiceConnections(ctx context.Context, projectId, vpcId string) ([]*servicenetworking.Connection, error)
-	CreateServiceConnection(ctx context.Context, projectId, vpcId, reservedIpRangeName string) (*servicenetworking.Operation, error)
+	CreateServiceConnection(ctx context.Context, projectId, vpcId string, reservedIpRanges []string) (*servicenetworking.Operation, error)
+	DeleteServiceConnection(ctx context.Context, projectId, vpcId string) (*servicenetworking.Operation, error)
+	PatchServiceConnection(ctx context.Context, projectId, vpcId string, reservedIpRanges []string) (*servicenetworking.Operation, error)
 }
 
 func NewServiceNetworkingClient() gcpclient.ClientProvider[ServiceNetworkingClient] {
@@ -33,6 +35,21 @@ type serviceNetworkingClient struct {
 	svcNet *servicenetworking.APIService
 }
 
+func (c *serviceNetworkingClient) PatchServiceConnection(ctx context.Context, projectId, vpcId string, reservedIpRanges []string) (*servicenetworking.Operation, error) {
+	network := gcpclient.GetVPCPath(projectId, vpcId)
+	return c.svcNet.Services.Connections.Patch(gcpclient.ServiceNetworkingServiceConnectionName, &servicenetworking.Connection{
+		Network: network,
+		ReservedPeeringRanges: reservedIpRanges,
+	}).Do()
+}
+
+func (c *serviceNetworkingClient) DeleteServiceConnection(ctx context.Context, projectId, vpcId string) (*servicenetworking.Operation, error) {
+	network := gcpclient.GetVPCPath(projectId, vpcId)
+	return c.svcNet.Services.Connections.DeleteConnection(gcpclient.ServiceNetworkingServiceConnectionName, &servicenetworking.DeleteConnectionRequest{
+		ConsumerNetwork: network,
+	}).Do()
+}
+
 func (c *serviceNetworkingClient) ListServiceConnections(ctx context.Context, projectId, vpcId string) ([]*servicenetworking.Connection, error) {
 	network := gcpclient.GetVPCPath(projectId, vpcId)
 	out, err := c.svcNet.Services.Connections.List(gcpclient.ServiceNetworkingServicePath).Network(network).Do()
@@ -42,10 +59,8 @@ func (c *serviceNetworkingClient) ListServiceConnections(ctx context.Context, pr
 	return out.Connections, nil
 }
 
-func (c *serviceNetworkingClient) CreateServiceConnection(ctx context.Context, projectId, vpcId, reservedIpRangeName string) (*servicenetworking.Operation, error) {
+func (c *serviceNetworkingClient) CreateServiceConnection(ctx context.Context, projectId, vpcId string, reservedIpRanges []string) (*servicenetworking.Operation, error) {
 	network := gcpclient.GetVPCPath(projectId, vpcId)
-	var reservedIpRanges []string
-	reservedIpRanges = append(reservedIpRanges, reservedIpRangeName)
 	return c.svcNet.Services.Connections.Create(gcpclient.ServiceNetworkingServicePath, &servicenetworking.Connection{
 		Network:               network,
 		ReservedPeeringRanges: reservedIpRanges,


### PR DESCRIPTION

**Adding more APIs to gcp compute and serviceNetworking client**

Changes proposed in this pull request:

- adding DeleteIpRange and GetIpRange to gcp ComputeClient for ipRange
- adding DeleteServiceConnection and PatchServiceConnection to gcp ServiceNetworkingClient for ipRange

