### PR TITLE
SKR looper and controller manager

### DIFF
--- a/components/kcp/internal/controller/cloud-resources/cloudresources_controller.go
+++ b/components/kcp/internal/controller/cloud-resources/cloudresources_controller.go
@@ -18,17 +18,29 @@ package cloudresources
 
 import (
 	"context"
+	cloudresourcesv1beta1 "github.com/kyma-project/cloud-manager/components/kcp/api/cloud-resources/v1beta1"
+	"github.com/kyma-project/cloud-manager/components/kcp/pkg/skr/registry"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+type CloudResourcesFactory struct {
+}
+
+func (f *CloudResourcesFactory) New(kcpCluster cluster.Cluster, skrCluster cluster.Cluster) reconcile.Reconciler {
+	return &CloudResourcesReconciler{
+		kcpCluster: kcpCluster,
+		skrCluster: skrCluster,
+	}
+}
+
 // CloudResourcesReconciler reconciles a CloudResources object
 type CloudResourcesReconciler struct {
-	client.Client
-	Scheme *runtime.Scheme
+	kcpCluster cluster.Cluster
+	skrCluster cluster.Cluster
 }
 
 //+kubebuilder:rbac:groups=cloud-resources.kyma-project.io,resources=cloudresources,verbs=get;list;watch;create;update;patch;delete
@@ -45,17 +57,16 @@ type CloudResourcesReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.16.3/pkg/reconcile
 func (r *CloudResourcesReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
-	// TODO(user): your logic here
+	logger.Info("Hello from CloudResourcesReconciler!")
 
 	return ctrl.Result{}, nil
 }
 
-// SetupWithManager sets up the controller with the Manager.
-func (r *CloudResourcesReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return nil
-	//return ctrl.NewControllerManagedBy(mgr).
-	//	For(&cloudresourcesv1beta1.CloudResources{}).
-	//	Complete(r)
+func SetupCloudResourcesReconciler(reg registry.SkrRegistry) error {
+	return reg.Register().
+		WithFactory(&CloudResourcesFactory{}).
+		For(&cloudresourcesv1beta1.CloudResources{}).
+		Complete()
 }

--- a/components/kcp/pkg/common/actions/focal/fixInvalidScopeRef.go
+++ b/components/kcp/pkg/common/actions/focal/fixInvalidScopeRef.go
@@ -10,7 +10,6 @@ import (
 func fixInvalidScopeRef(ctx context.Context, st composed.State) (error, context.Context) {
 	logger := composed.LoggerFromCtx(ctx)
 	state := st.(State)
-
 	scopeRef := state.ObjAsCommonObj().ScopeRef()
 	scope := state.Scope()
 	if scopeRef == nil && scope == nil {

--- a/components/kcp/pkg/provider/gcp/iprange/client/serviceNetworkingClient.go
+++ b/components/kcp/pkg/provider/gcp/iprange/client/serviceNetworkingClient.go
@@ -10,9 +10,7 @@ import (
 
 type ServiceNetworkingClient interface {
 	ListServiceConnections(ctx context.Context, projectId, vpcId string) ([]*servicenetworking.Connection, error)
-	CreateServiceConnection(ctx context.Context, projectId, vpcId string, reservedIpRanges []string) (*servicenetworking.Operation, error)
-	DeleteServiceConnection(ctx context.Context, projectId, vpcId string) (*servicenetworking.Operation, error)
-	PatchServiceConnection(ctx context.Context, projectId, vpcId string, reservedIpRanges []string) (*servicenetworking.Operation, error)
+	CreateServiceConnection(ctx context.Context, projectId, vpcId, reservedIpRangeName string) (*servicenetworking.Operation, error)
 }
 
 func NewServiceNetworkingClient() gcpclient.ClientProvider[ServiceNetworkingClient] {
@@ -35,21 +33,6 @@ type serviceNetworkingClient struct {
 	svcNet *servicenetworking.APIService
 }
 
-func (c *serviceNetworkingClient) PatchServiceConnection(ctx context.Context, projectId, vpcId string, reservedIpRanges []string) (*servicenetworking.Operation, error) {
-	network := gcpclient.GetVPCPath(projectId, vpcId)
-	return c.svcNet.Services.Connections.Patch(gcpclient.ServiceNetworkingServiceConnectionName, &servicenetworking.Connection{
-		Network: network,
-		ReservedPeeringRanges: reservedIpRanges,
-	}).Do()
-}
-
-func (c *serviceNetworkingClient) DeleteServiceConnection(ctx context.Context, projectId, vpcId string) (*servicenetworking.Operation, error) {
-	network := gcpclient.GetVPCPath(projectId, vpcId)
-	return c.svcNet.Services.Connections.DeleteConnection(gcpclient.ServiceNetworkingServiceConnectionName, &servicenetworking.DeleteConnectionRequest{
-		ConsumerNetwork: network,
-	}).Do()
-}
-
 func (c *serviceNetworkingClient) ListServiceConnections(ctx context.Context, projectId, vpcId string) ([]*servicenetworking.Connection, error) {
 	network := gcpclient.GetVPCPath(projectId, vpcId)
 	out, err := c.svcNet.Services.Connections.List(gcpclient.ServiceNetworkingServicePath).Network(network).Do()
@@ -59,8 +42,10 @@ func (c *serviceNetworkingClient) ListServiceConnections(ctx context.Context, pr
 	return out.Connections, nil
 }
 
-func (c *serviceNetworkingClient) CreateServiceConnection(ctx context.Context, projectId, vpcId string, reservedIpRanges []string) (*servicenetworking.Operation, error) {
+func (c *serviceNetworkingClient) CreateServiceConnection(ctx context.Context, projectId, vpcId, reservedIpRangeName string) (*servicenetworking.Operation, error) {
 	network := gcpclient.GetVPCPath(projectId, vpcId)
+	var reservedIpRanges []string
+	reservedIpRanges = append(reservedIpRanges, reservedIpRangeName)
 	return c.svcNet.Services.Connections.Create(gcpclient.ServiceNetworkingServicePath, &servicenetworking.Connection{
 		Network:               network,
 		ReservedPeeringRanges: reservedIpRanges,

--- a/components/kcp/pkg/provider/gcp/iprange/loadAddress.go
+++ b/components/kcp/pkg/provider/gcp/iprange/loadAddress.go
@@ -16,8 +16,8 @@ func loadAddress(ctx context.Context, st composed.State) (error, context.Context
 	//Get from GCP.
 	gcpScope := state.Scope().Spec.Scope.Gcp
 	project := gcpScope.Project
-	vpc := gcpScope.VpcNetwork
-	list, err := state.computeClient.ListGlobalAddresses(ctx, project, vpc)
+	//vpc := gcpScope.VpcNetwork
+	list, err := state.computeClient.ListGlobalAddresses(ctx, project)
 	if err != nil {
 		return err, nil
 	}

--- a/components/kcp/pkg/skr/cache/cache.go
+++ b/components/kcp/pkg/skr/cache/cache.go
@@ -1,0 +1,276 @@
+package cache
+
+// Based on sigs.k8s.io/controller-runtime@v0.16.3/pkg/cache/internal/cache_reader.go
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-logr/logr"
+	"github.com/kyma-project/cloud-manager/components/kcp/pkg/util"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
+	clientcache "k8s.io/client-go/tools/cache"
+	"net/http"
+	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ SkrCache = &skrCache{}
+
+type SkrCache interface {
+	cache.Cache
+	GetIndexerFor(gvk schema.GroupVersionKind) clientcache.Indexer
+}
+
+func New(
+	logger logr.Logger,
+	scheme *runtime.Scheme,
+	mapper meta.RESTMapper,
+) SkrCache {
+	return &skrCache{
+		logger:   logger,
+		scheme:   scheme,
+		mapper:   mapper,
+		indexers: map[schema.GroupVersionKind]clientcache.Indexer{},
+	}
+}
+
+// skrCache is the controller-runtime Cache implementation
+// that is given to the Client, it only implements the Reader
+// since the rest of the Cache methods are not used in the Client
+type skrCache struct {
+	logger   logr.Logger
+	scheme   *runtime.Scheme
+	mapper   meta.RESTMapper
+	indexers map[schema.GroupVersionKind]clientcache.Indexer
+}
+
+func (c *skrCache) GetIndexerFor(gvk schema.GroupVersionKind) clientcache.Indexer {
+	i, exists := c.indexers[gvk]
+	if !exists {
+		i := clientcache.NewIndexer(clientcache.MetaNamespaceKeyFunc, clientcache.Indexers{
+			clientcache.NamespaceIndex: clientcache.MetaNamespaceIndexFunc,
+		})
+		c.indexers[gvk] = i
+	}
+	return i
+}
+
+func (c *skrCache) Get(ctx context.Context, key client.ObjectKey, out client.Object, opts ...client.GetOption) error {
+	gvk, err := util.GetObjGvk(c.scheme, out)
+	if err != nil {
+		return err
+	}
+
+	indexer, exists := c.indexers[gvk]
+	if !exists {
+		return &apierrors.StatusError{ErrStatus: metav1.Status{
+			Status: metav1.StatusFailure,
+			Code:   http.StatusNotFound,
+			Reason: metav1.StatusReasonNotFound,
+			Details: &metav1.StatusDetails{
+				Group: gvk.Group,
+				Kind:  gvk.Kind,
+				Name:  key.Name,
+			},
+			Message: fmt.Sprintf("GVK %s is not cached", gvk),
+		}}
+	}
+
+	mapping, err := c.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return err
+	}
+	if mapping.Scope.Name() == apimeta.RESTScopeNameRoot {
+		key.Namespace = ""
+	}
+
+	storeKey, err := clientcache.MetaNamespaceKeyFunc(out)
+	if err != nil {
+		return err
+	}
+
+	obj, exists, err := indexer.GetByKey(storeKey)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return apierrors.NewNotFound(schema.GroupResource{
+			Group: gvk.Group,
+			// Resource gets set as Kind in the error so this is fine
+			Resource: gvk.Kind,
+		}, key.Name)
+	}
+
+	if _, isObj := obj.(runtime.Object); !isObj {
+		// This should never happen
+		return fmt.Errorf("cache contained %T, which is not an Object", obj)
+	}
+
+	obj = obj.(runtime.Object).DeepCopyObject()
+
+	outVal := reflect.ValueOf(out)
+	objVal := reflect.ValueOf(obj)
+	if !objVal.Type().AssignableTo(outVal.Type()) {
+		return fmt.Errorf("cache had type %s, but %s was asked for", objVal.Type(), outVal.Type())
+	}
+	reflect.Indirect(outVal).Set(reflect.Indirect(objVal))
+	out.GetObjectKind().SetGroupVersionKind(gvk)
+
+	return nil
+}
+
+func (c *skrCache) List(ctx context.Context, out client.ObjectList, opts ...client.ListOption) error {
+	listGvk, err := util.GetObjGvk(c.scheme, out)
+	if err != nil {
+		return err
+	}
+	gvk, err := util.GetObjGvkFromListGkv(c.scheme, listGvk)
+	if err != nil {
+		return err
+	}
+
+	indexer, exists := c.indexers[gvk]
+	if !exists {
+		return &apierrors.StatusError{ErrStatus: metav1.Status{
+			Status: metav1.StatusFailure,
+			Code:   http.StatusNotFound,
+			Reason: metav1.StatusReasonNotFound,
+			Details: &metav1.StatusDetails{
+				Group: gvk.Group,
+				Kind:  gvk.Kind,
+			},
+			Message: fmt.Sprintf("GVK %s is not cached", gvk),
+		}}
+	}
+
+	var objs []interface{}
+
+	listOpts := client.ListOptions{}
+	listOpts.ApplyOptions(opts)
+
+	if listOpts.Continue != "" {
+		return fmt.Errorf("continue list option is not supported by the cache")
+	}
+
+	switch {
+	case listOpts.FieldSelector != nil:
+		field, val, requiresExact := requiresExactMatch(listOpts.FieldSelector)
+		if !requiresExact {
+			return fmt.Errorf("non-exact field matches are not supported by the cache")
+		}
+		// list all objects by the field selector. If this is namespaced and we have one, ask for the
+		// namespaced index key. Otherwise, ask for the non-namespaced variant by using the fake "all namespaces"
+		// namespace.
+		objs, err = indexer.ByIndex(fieldIndexName(field), keyToNamespacedKey(listOpts.Namespace, val))
+	case listOpts.Namespace != "":
+		objs, err = indexer.ByIndex(clientcache.NamespaceIndex, listOpts.Namespace)
+	default:
+		objs = indexer.List()
+	}
+	if err != nil {
+		return err
+	}
+	var labelSel labels.Selector
+	if listOpts.LabelSelector != nil {
+		labelSel = listOpts.LabelSelector
+	}
+
+	limitSet := listOpts.Limit > 0
+
+	runtimeObjs := make([]runtime.Object, 0, len(objs))
+	for _, item := range objs {
+		// if the Limit option is set and the number of items
+		// listed exceeds this limit, then stop reading.
+		if limitSet && int64(len(runtimeObjs)) >= listOpts.Limit {
+			break
+		}
+		obj, isObj := item.(runtime.Object)
+		if !isObj {
+			return fmt.Errorf("cache contained %T, which is not an Object", item)
+		}
+		metaAcc, err := apimeta.Accessor(obj)
+		if err != nil {
+			return err
+		}
+		if labelSel != nil {
+			lbls := labels.Set(metaAcc.GetLabels())
+			if !labelSel.Matches(lbls) {
+				continue
+			}
+		}
+
+		var outObj runtime.Object
+		if listOpts.UnsafeDisableDeepCopy != nil && *listOpts.UnsafeDisableDeepCopy {
+			// skip deep copy which might be unsafe
+			// you must DeepCopy any object before mutating it outside
+			outObj = obj
+		} else {
+			outObj = obj.DeepCopyObject()
+			outObj.GetObjectKind().SetGroupVersionKind(gvk)
+		}
+		runtimeObjs = append(runtimeObjs, outObj)
+	}
+	return apimeta.SetList(out, runtimeObjs)
+}
+
+func (c *skrCache) GetInformer(ctx context.Context, obj client.Object, opts ...cache.InformerGetOption) (cache.Informer, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c *skrCache) GetInformerForKind(ctx context.Context, gvk schema.GroupVersionKind, opts ...cache.InformerGetOption) (cache.Informer, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c *skrCache) Start(ctx context.Context) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c *skrCache) WaitForCacheSync(ctx context.Context) bool {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c *skrCache) IndexField(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func requiresExactMatch(sel fields.Selector) (field, val string, required bool) {
+	reqs := sel.Requirements()
+	if len(reqs) != 1 {
+		return "", "", false
+	}
+	req := reqs[0]
+	if req.Operator != selection.Equals && req.Operator != selection.DoubleEquals {
+		return "", "", false
+	}
+	return req.Field, req.Value, true
+}
+
+func fieldIndexName(field string) string {
+	return "field:" + field
+}
+
+// allNamespacesNamespace is used as the "namespace" when we want to list across all namespaces.
+const allNamespacesNamespace = "__all_namespaces"
+
+// KeyToNamespacedKey prefixes the given index key with a namespace
+// for use in field selector indexes.
+func keyToNamespacedKey(ns string, baseKey string) string {
+	if ns != "" {
+		return ns + "/" + baseKey
+	}
+	return allNamespacesNamespace + "/" + baseKey
+}

--- a/components/kcp/pkg/skr/looper/runner.go
+++ b/components/kcp/pkg/skr/looper/runner.go
@@ -1,0 +1,116 @@
+package looper
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	skrmanager "github.com/kyma-project/cloud-manager/components/kcp/pkg/skr/manager"
+	"github.com/kyma-project/cloud-manager/components/kcp/pkg/skr/registry"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"strings"
+	"sync"
+	"time"
+)
+
+type RunOptions struct {
+	timeout time.Duration
+}
+
+type RunOption = func(options *RunOptions)
+
+func WithTimeout(timeout time.Duration) RunOption {
+	return func(options *RunOptions) {
+		options.timeout = timeout
+	}
+}
+
+type SkrRunner interface {
+	Run(ctx context.Context, mngr skrmanager.SkrManager, opts ...RunOption)
+	GetControllerOptions(
+		descriptor registry.Descriptor,
+		skrManager skrmanager.SkrManager,
+	) controller.Options
+}
+
+func NewSkrRunner(reg registry.SkrRegistry, kcpCluster cluster.Cluster) SkrRunner {
+	return &skrRunner{
+		kcpCluster: kcpCluster,
+		registry:   reg,
+	}
+}
+
+type skrRunner struct {
+	kcpCluster cluster.Cluster
+	registry   registry.SkrRegistry
+	runOnce    sync.Once
+}
+
+func (r *skrRunner) Run(ctx context.Context, mngr skrmanager.SkrManager, opts ...RunOption) {
+	options := &RunOptions{}
+	for _, o := range opts {
+		o(options)
+	}
+	r.runOnce.Do(func() {
+		for _, descr := range r.registry.GetDescriptors(mngr) {
+			logger2 := mngr.GetLogger().WithValues("controller", descr.Name)
+			ctrl, err := controller.New(descr.Name, mngr, r.GetControllerOptions(
+				descr,
+				mngr,
+			))
+			if err != nil {
+				logger2.Error(err, "error creating controller")
+				continue
+			}
+			for _, w := range descr.Watches {
+				err = ctrl.Watch(w.Src, w.EventHandler, w.Predicates...)
+				if err != nil {
+					logger2.WithValues("watch", w.Name).Error(err, "error watching source")
+					continue
+				}
+			}
+		}
+
+		if options.timeout == 0 {
+			options.timeout = time.Minute
+		}
+		timeoutCtx, cancel := context.WithTimeout(ctx, options.timeout)
+		defer cancel()
+		err := mngr.Start(timeoutCtx)
+		if err != nil {
+			mngr.GetLogger().Error(err, "error starting manager")
+		}
+	})
+}
+
+func (r *skrRunner) GetControllerOptions(descriptor registry.Descriptor, skrManager skrmanager.SkrManager) controller.Options {
+	controllerName := descriptor.Name
+	if len(controllerName) == 0 {
+		controllerName = strings.ToLower(descriptor.GVK.Kind)
+	}
+	logger := skrManager.GetLogger().WithValues(
+		"controller", controllerName,
+		"controllerGroup", descriptor.GVK.Group,
+		"controllerKind", descriptor.GVK.Kind,
+	)
+	ctrlOptions := controller.Options{
+		Reconciler: descriptor.ReconcilerFactory.New(r.kcpCluster, skrManager),
+		// TODO: copy other options,
+		// for details check:
+		//  * sigs.k8s.io/controller-runtime@v0.16.3/pkg/controller/controller.go
+		//  * sigs.k8s.io/controller-runtime@v0.16.3/pkg/builder/controller.go
+		MaxConcurrentReconciles: skrManager.GetControllerOptions().MaxConcurrentReconciles,
+		LogConstructor: func(req *reconcile.Request) logr.Logger {
+			logger := logger
+			if req != nil {
+				logger = logger.WithValues(
+					descriptor.GVK.Kind, klog.KRef(req.Namespace, req.Name),
+					"namespace", req.Namespace, "name", req.Name,
+				)
+			}
+			return logger
+		},
+	}
+	return ctrlOptions
+}

--- a/components/kcp/pkg/skr/looper/skrLooper.go
+++ b/components/kcp/pkg/skr/looper/skrLooper.go
@@ -1,0 +1,167 @@
+package looper
+
+import (
+	"context"
+	"errors"
+	"github.com/elliotchance/pie/v2"
+	"github.com/go-logr/logr"
+	skrmanager "github.com/kyma-project/cloud-manager/components/kcp/pkg/skr/manager"
+	"github.com/kyma-project/cloud-manager/components/kcp/pkg/skr/registry"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sync"
+	"time"
+)
+
+type SkrLooper interface {
+	manager.Runnable
+	AddKymaName(kymaName string)
+	RemoveKymaName(kymaName string)
+}
+
+func New(kcpCluster cluster.Cluster, skrScheme *runtime.Scheme, reg registry.SkrRegistry, logger logr.Logger) SkrLooper {
+	return &skrLooper{
+		kcpCluster:     kcpCluster,
+		managerFactory: skrmanager.NewFactory(kcpCluster.GetAPIReader(), "kcp-system", skrScheme),
+		registry:       reg,
+		logger:         logger,
+		concurrency:    1,
+		ch:             make(chan string, 1),
+	}
+}
+
+type skrLooper struct {
+	mu sync.RWMutex
+
+	kcpCluster     cluster.Cluster
+	managerFactory skrmanager.Factory
+	registry       registry.SkrRegistry
+	logger         logr.Logger
+	concurrency    int
+
+	// wg the WorkGroup for workers
+	wg      sync.WaitGroup
+	started bool
+	stopped bool
+
+	// ch the channel trough which kymaNames sent to the workers
+	ch chan string
+
+	// ctx the Context looper was started with
+	ctx context.Context
+
+	// kymaNames slice of active SKRs that have to be looped trough
+	kymaNames []string
+}
+
+func (l *skrLooper) AddKymaName(kymaName string) {
+	l.mu.Lock()
+	l.kymaNames = append(l.kymaNames, kymaName)
+	l.mu.Unlock()
+}
+
+func (l *skrLooper) RemoveKymaName(kymaName string) {
+	l.mu.Lock()
+	idx := pie.FindFirstUsing(l.kymaNames, func(value string) bool {
+		return value == kymaName
+	})
+	if idx > -1 {
+		l.kymaNames = pie.Delete(l.kymaNames, idx)
+	}
+	l.mu.Unlock()
+}
+
+func (l *skrLooper) Start(ctx context.Context) error {
+	if l.started {
+		return errors.New("looper already started")
+	}
+
+	l.logger.Info("SkrLooper started")
+	l.ctx = ctx
+	l.ch = make(chan string, l.concurrency)
+	l.started = true
+	for x := 0; x < l.concurrency; x++ {
+		go l.worker()
+	}
+	go l.emitActiveKymaNames()
+
+	<-ctx.Done()
+
+	l.stopped = true
+	l.wg.Wait()
+	close(l.ch)
+	l.ch = nil
+	l.logger.Info("SkrLooper stopped")
+	return nil
+}
+
+func (l *skrLooper) getKymaNames() []string {
+	var kymaNames []string
+	l.mu.RLock()
+	kymaNames = make([]string, len(l.kymaNames))
+	for x := range l.kymaNames {
+		kymaNames[x] = l.kymaNames[x]
+	}
+	l.mu.RUnlock()
+	return kymaNames
+}
+
+func (l *skrLooper) emitActiveKymaNames() {
+	l.wg.Add(1)
+	defer l.wg.Done()
+	for !l.stopped {
+		kymaNames := l.getKymaNames()
+		for _, kn := range kymaNames {
+			if l.stopped {
+				return
+			}
+			select {
+			case <-l.ctx.Done():
+				return
+			case l.ch <- kn:
+			}
+		}
+		time.Sleep(time.Second)
+	}
+}
+
+func (l *skrLooper) worker() {
+	l.wg.Add(1)
+	defer l.wg.Done()
+	for !l.stopped {
+		kymaName := <-l.ch
+		if l.stopped {
+			break
+		}
+		time.Sleep(time.Second)
+		l.handleOneSkr(kymaName)
+	}
+}
+
+func (l *skrLooper) handleOneSkr(kymaName string) {
+	logger := l.logger.WithValues("skrKymaName", kymaName)
+	mngr, err := l.managerFactory.CreateManager(l.ctx, kymaName, logger)
+	if err != nil {
+		logger.Error(err, "error creating Manager")
+	}
+
+	logger.Info("Starting runner")
+	runner := NewSkrRunner(l.registry, mngr)
+	runner.Run(l.ctx, mngr, WithTimeout(30*time.Second))
+	logger.Info("Runner stopped")
+}
+
+func (l *skrLooper) getControllerOptions(
+	reconcilerFactory registry.ReconcilerFactory,
+	skrManager skrmanager.SkrManager,
+) controller.Options {
+	ctrlOptions := controller.Options{
+		Reconciler: reconcilerFactory.New(l.kcpCluster, skrManager),
+		// TODO: copy other options,
+		// check sigs.k8s.io/controller-runtime@v0.16.3/pkg/controller/controller.go for details
+		MaxConcurrentReconciles: skrManager.GetControllerOptions().MaxConcurrentReconciles,
+	}
+	return ctrlOptions
+}

--- a/components/kcp/pkg/skr/manager/factory.go
+++ b/components/kcp/pkg/skr/manager/factory.go
@@ -1,0 +1,56 @@
+package manager
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+var _ Factory = &skrManagerFactory{}
+
+type Factory interface {
+	CreateManager(ctx context.Context, kymaName string, logger logr.Logger) (manager.Manager, error)
+}
+
+func NewFactory(kcpClient client.Reader, namespace string, skrScheme *runtime.Scheme) Factory {
+	return &skrManagerFactory{
+		kcpClient: kcpClient,
+		namespace: namespace,
+		skrScheme: skrScheme,
+	}
+}
+
+type skrManagerFactory struct {
+	kcpClient client.Reader
+	namespace string
+	skrScheme *runtime.Scheme
+}
+
+func (f *skrManagerFactory) CreateManager(ctx context.Context, kymaName string, logger logr.Logger) (manager.Manager, error) {
+	secret := &corev1.Secret{}
+	name := fmt.Sprintf("kubeconfig-%s", kymaName)
+	err := f.kcpClient.Get(ctx, types.NamespacedName{
+		Namespace: f.namespace,
+		Name:      name,
+	}, secret)
+	if err != nil {
+		return nil, fmt.Errorf("error getting kubeconfig secret: %w", err)
+	}
+	b := secret.Data["config"]
+	cc, err := clientcmd.NewClientConfigFromBytes(b)
+	if err != nil {
+		return nil, fmt.Errorf("error loading kubeconfig: %w", err)
+	}
+	restConfig, err := cc.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("error getting rest config from kubeconfig: %w", err)
+	}
+
+	return New(restConfig, f.skrScheme, logger)
+}

--- a/components/kcp/pkg/skr/manager/manager.go
+++ b/components/kcp/pkg/skr/manager/manager.go
@@ -1,0 +1,113 @@
+package manager
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	skrcache "github.com/kyma-project/cloud-manager/components/kcp/pkg/skr/cache"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sync"
+)
+
+var _ SkrManager = &skrManager{}
+
+type SkrManager interface {
+	manager.Manager
+}
+
+func New(cfg *rest.Config, skrScheme *runtime.Scheme, logger logr.Logger) (SkrManager, error) {
+	cls, err := cluster.New(cfg, func(clusterOptions *cluster.Options) {
+		clusterOptions.Scheme = skrScheme
+		clusterOptions.Logger = logger
+		clusterOptions.NewCache = func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
+			return skrcache.New(logger, opts.Scheme, opts.Mapper), nil
+		}
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &skrManager{
+		Cluster: cls,
+		logger:  logger,
+	}, nil
+}
+
+type skrManager struct {
+	cluster.Cluster
+
+	logger      logr.Logger
+	controllers []manager.Runnable
+}
+
+func (m *skrManager) Start(ctx context.Context) error {
+	m.logger.Info("SkrManager started")
+	var wg sync.WaitGroup
+	for _, r := range m.controllers {
+		ctrl, ok := r.(controller.Controller)
+		if !ok {
+			continue
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := ctrl.Start(ctx)
+			if err != nil {
+				ctrl.GetLogger().Error(err, "error starting controller")
+				return
+			}
+		}()
+	}
+
+	<-ctx.Done()
+	wg.Wait()
+	m.logger.Info("SkrManager stopped")
+
+	return nil
+}
+
+func (m *skrManager) Add(runnable manager.Runnable) error {
+	m.controllers = append(m.controllers, runnable)
+	return nil
+}
+
+func (m *skrManager) Elected() <-chan struct{} {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *skrManager) AddHealthzCheck(name string, check healthz.Checker) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *skrManager) AddReadyzCheck(name string, check healthz.Checker) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *skrManager) GetWebhookServer() webhook.Server {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *skrManager) GetLogger() logr.Logger {
+	return m.logger
+}
+
+func (m *skrManager) GetControllerOptions() config.Controller {
+	resulut := config.Controller{
+		GroupKindConcurrency:    nil,
+		MaxConcurrentReconciles: 1,
+		CacheSyncTimeout:        0,
+		RecoverPanic:            nil,
+		NeedLeaderElection:      nil,
+	}
+	return resulut
+}

--- a/components/kcp/pkg/skr/registry/builder.go
+++ b/components/kcp/pkg/skr/registry/builder.go
@@ -1,0 +1,113 @@
+package registry
+
+import (
+	"errors"
+	"fmt"
+	"github.com/kyma-project/cloud-manager/components/kcp/pkg/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"strings"
+)
+
+var _ Builder = &skrBuilder{}
+
+type Builder interface {
+	WithFactory(f ReconcilerFactory) Builder
+
+	Named(name string) Builder
+	For(object client.Object, opts ...ForOption) Builder
+	Watches(object client.Object, eventHandler handler.EventHandler, opts ...WatchesOption) Builder
+	Complete() error
+}
+
+type skrBuilder struct {
+	registry     *skrRegistry
+	factory      ReconcilerFactory
+	name         string
+	forInput     *ForInput
+	watchesInput []*WatchesInput
+}
+
+func (b *skrBuilder) Named(name string) Builder {
+	b.name = name
+	return b
+}
+
+func (b *skrBuilder) WithFactory(f ReconcilerFactory) Builder {
+	b.factory = f
+	return b
+}
+
+func (b *skrBuilder) For(object client.Object, opts ...ForOption) Builder {
+	in := &ForInput{object: object}
+	for _, opt := range opts {
+		opt.ApplyToFor(in)
+	}
+	b.forInput = in
+	return b
+}
+
+func (b *skrBuilder) Watches(object client.Object, eventHandler handler.EventHandler, opts ...WatchesOption) Builder {
+	in := &WatchesInput{object: object}
+	for _, opt := range opts {
+		opt.ApplyToWatches(in)
+	}
+	b.watchesInput = append(b.watchesInput, in)
+	return b
+}
+
+func (b *skrBuilder) Complete() error {
+	if b.factory == nil {
+		return errors.New("the WithFactory(...) method must be called to define reconciler factory")
+	}
+	if b.forInput == nil {
+		return errors.New("the For(...) method must be called to define reconciled object")
+	}
+
+	gvk, err := util.GetObjGvk(b.registry.scheme, b.forInput.object)
+	if err != nil {
+		return err
+	}
+
+	name := b.name
+	if len(name) == 0 {
+		name = strings.ToLower(gvk.Kind)
+	}
+	item := &registryItem{
+		name:              name,
+		reconcilerFactory: b.factory,
+	}
+
+	gvk, err = util.GetObjGvk(b.registry.scheme, b.forInput.object)
+	if err != nil {
+		return err
+	}
+	hdler := &handler.EnqueueRequestForObject{}
+	item.watches = append(item.watches, &registryItemWatch{
+		name:         fmt.Sprintf("%s/%s/%s", gvk.Group, gvk.Version, gvk.Kind),
+		object:       b.forInput.object,
+		gvk:          gvk,
+		eventHandler: hdler,
+		predicates:   nil,
+	})
+
+	for _, w := range b.watchesInput {
+		gvk, err := util.GetObjGvk(b.registry.scheme, w.object)
+		if err != nil {
+			return err
+		}
+		wi := &registryItemWatch{
+			name:         gvk.String(),
+			object:       w.object,
+			gvk:          gvk,
+			eventHandler: w.eventHandler,
+			predicates:   w.predicates,
+		}
+
+		item.watches = append(item.watches, wi)
+	}
+
+	b.registry.addItem(item)
+
+	return nil
+}

--- a/components/kcp/pkg/skr/registry/options.go
+++ b/components/kcp/pkg/skr/registry/options.go
@@ -1,0 +1,27 @@
+package registry
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+type ForInput struct {
+	object client.Object
+}
+
+type ForOption interface {
+	// ApplyToFor applies this configuration to the given for input.
+	ApplyToFor(*ForInput)
+}
+
+type WatchesInput struct {
+	object       client.Object
+	eventHandler handler.EventHandler
+	predicates   []predicate.Predicate
+}
+
+type WatchesOption interface {
+	// ApplyToWatches applies this configuration to the given watches options.
+	ApplyToWatches(*WatchesInput)
+}

--- a/components/kcp/pkg/skr/registry/registry.go
+++ b/components/kcp/pkg/skr/registry/registry.go
@@ -1,0 +1,95 @@
+package registry
+
+import (
+	skrcache "github.com/kyma-project/cloud-manager/components/kcp/pkg/skr/cache"
+	"github.com/kyma-project/cloud-manager/components/kcp/pkg/skr/manager"
+	skrsource "github.com/kyma-project/cloud-manager/components/kcp/pkg/skr/source"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+type ReconcilerFactory interface {
+	New(kcpCluster cluster.Cluster, skrCluster cluster.Cluster) reconcile.Reconciler
+}
+
+type Watch struct {
+	Name         string
+	Src          source.Source
+	EventHandler handler.EventHandler
+	Predicates   []predicate.Predicate
+}
+
+type Descriptor struct {
+	Name              string
+	GVK               schema.GroupVersionKind
+	Watches           []Watch
+	ReconcilerFactory ReconcilerFactory
+}
+
+type SkrRegistry interface {
+	GetDescriptors(mngr manager.SkrManager) []Descriptor
+	Register() Builder
+}
+
+func New(scheme *runtime.Scheme) SkrRegistry {
+	return &skrRegistry{
+		scheme: scheme,
+	}
+}
+
+type registryItem struct {
+	name              string
+	reconcilerFactory ReconcilerFactory
+	watches           []*registryItemWatch
+}
+
+type registryItemWatch struct {
+	name         string
+	object       client.Object
+	gvk          schema.GroupVersionKind
+	eventHandler handler.EventHandler
+	predicates   []predicate.Predicate
+}
+
+type skrRegistry struct {
+	scheme *runtime.Scheme
+	items  []*registryItem
+}
+
+func (r *skrRegistry) GetDescriptors(mngr manager.SkrManager) []Descriptor {
+	result := make([]Descriptor, 0, len(r.items))
+	cch := mngr.GetCache().(skrcache.SkrCache)
+	for _, item := range r.items {
+		d := Descriptor{
+			Name:              item.name,
+			GVK:               item.watches[0].gvk,
+			ReconcilerFactory: item.reconcilerFactory,
+		}
+		for _, wi := range item.watches {
+			src := skrsource.New(mngr.GetScheme(), mngr.GetAPIReader(), wi.gvk, cch.GetIndexerFor(wi.gvk))
+			w := Watch{
+				Name:         wi.name,
+				Src:          src,
+				EventHandler: wi.eventHandler,
+				Predicates:   wi.predicates,
+			}
+			d.Watches = append(d.Watches, w)
+		}
+		result = append(result, d)
+	}
+	return result
+}
+
+func (r *skrRegistry) Register() Builder {
+	return &skrBuilder{registry: r}
+}
+
+func (r *skrRegistry) addItem(item *registryItem) {
+	r.items = append(r.items, item)
+}

--- a/components/kcp/pkg/skr/source/source.go
+++ b/components/kcp/pkg/skr/source/source.go
@@ -1,0 +1,103 @@
+package source
+
+import (
+	"context"
+	"fmt"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientcache "k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	ctrlsource "sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+var _ SkrSource = &skrSource{}
+
+type SkrSource interface {
+	ctrlsource.Source
+	IsStarted() bool
+	Queue() workqueue.RateLimitingInterface
+}
+
+func New(scheme *runtime.Scheme, skrApiReader client.Reader, gvk schema.GroupVersionKind, store clientcache.Store) SkrSource {
+	listGvk := schema.GroupVersionKind{
+		Group:   gvk.Group,
+		Version: gvk.Version,
+		Kind:    gvk.Kind + "List",
+	}
+	return &skrSource{
+		scheme:       scheme,
+		skrApiReader: skrApiReader,
+		objGvk:       gvk,
+		listGvk:      listGvk,
+		store:        store,
+	}
+}
+
+type skrSource struct {
+	scheme       *runtime.Scheme
+	skrApiReader client.Reader
+	objGvk       schema.GroupVersionKind
+	listGvk      schema.GroupVersionKind
+	store        clientcache.Store
+
+	started bool
+	queue   workqueue.RateLimitingInterface
+}
+
+func (s *skrSource) String() string {
+	return fmt.Sprintf("skr kind: %s", s.objGvk.Kind)
+}
+
+func (s *skrSource) IsStarted() bool {
+	return s.started
+}
+
+func (s *skrSource) Queue() workqueue.RateLimitingInterface {
+	return s.queue
+}
+
+func (s *skrSource) Start(ctx context.Context, handler handler.EventHandler, limitingInterface workqueue.RateLimitingInterface, predicate ...predicate.Predicate) error {
+	s.started = true
+	s.queue = limitingInterface
+
+	obj, err := s.scheme.New(s.listGvk)
+	if err != nil {
+		return fmt.Errorf("error instantiating new list object for %s: %w", s.listGvk, err)
+	}
+	list, ok := obj.(client.ObjectList)
+	if !ok {
+		return fmt.Errorf("the GVK %s is not a client.ObjectList", s.listGvk)
+	}
+
+	err = s.skrApiReader.List(ctx, list)
+	if err != nil {
+		return err
+	}
+	arr, err := apimeta.ExtractList(list)
+	if err != nil {
+		return err
+	}
+itemLoop:
+	for _, item := range arr {
+		obj, ok := item.(client.Object)
+		if !ok {
+			continue
+		}
+		evt := event.GenericEvent{Object: obj}
+
+		for _, p := range predicate {
+			if !p.Generic(evt) {
+				continue itemLoop
+			}
+		}
+
+		handler.Generic(ctx, evt, limitingInterface)
+	}
+
+	return nil
+}

--- a/components/kcp/pkg/util/scheme.go
+++ b/components/kcp/pkg/util/scheme.go
@@ -1,0 +1,39 @@
+package util
+
+import (
+	"fmt"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"reflect"
+	"strings"
+)
+
+func GetObjGvk(scheme *runtime.Scheme, out runtime.Object) (gvk schema.GroupVersionKind, e error) {
+	gvkArr, _, err := scheme.ObjectKinds(out)
+	if err != nil {
+		return gvk, err
+	}
+	if len(gvkArr) == 0 {
+		return gvk, runtime.NewNotRegisteredErrForType(scheme.Name(), reflect.TypeOf(out))
+	}
+	//if len(gvkArr) > 1 {
+	//	logger.Info("type %T has more then one Scheme registration", out)
+	//}
+	gvk = gvkArr[0]
+	return
+}
+
+func GetObjGvkFromListGkv(scheme *runtime.Scheme, listGvk schema.GroupVersionKind) (gvk schema.GroupVersionKind, e error) {
+	if !strings.HasSuffix(listGvk.Kind, "List") {
+		return gvk, fmt.Errorf("the GVK %s is not a list", listGvk)
+	}
+	kind := strings.TrimSuffix(listGvk.Kind, "List")
+	for item := range scheme.AllKnownTypes() {
+		if item.GroupVersion() == listGvk.GroupVersion() && item.Kind == kind {
+			return item, nil
+		}
+	}
+	targetGvk := listGvk
+	targetGvk.Kind = kind
+	return gvk, fmt.Errorf("the GVK %s unlisted from %s not found in scheme", targetGvk, listGvk)
+}

--- a/components/kcp/tools/dev/kind/.gitignore
+++ b/components/kcp/tools/dev/kind/.gitignore
@@ -1,2 +1,1 @@
-kubeconfig-garden.yaml
-kubeconfig-kcp.yaml
+kubeconfig-*.yaml

--- a/components/kcp/tools/dev/kind/create-skr.sh
+++ b/components/kcp/tools/dev/kind/create-skr.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+PROJECT_ROOT_DIR=`realpath "$SCRIPT_DIR/../../.."`
+
+kind create cluster --config - <<EOF
+`envsubst < $PROJECT_ROOT_DIR/tools/dev/kind/kind-skr-config.yaml`
+EOF
+
+kind export kubeconfig -n skr --kubeconfig $PROJECT_ROOT_DIR/tools/dev/kind/kubeconfig-skr.yaml

--- a/components/kcp/tools/dev/kind/kind-skr-config.yaml
+++ b/components/kcp/tools/dev/kind/kind-skr-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+name: skr
+nodes:
+  - role: control-plane
+    extraMounts:
+      - hostPath: $GOPATH
+        containerPath: /gopath


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- `SkrCache` the controller-runtime cache.Cache implementation w/out Informers, just with Indexers
- `SkrRunner` bootstraps and runs controller-runtime Controllers with `SkrManager` and controller definitions from `SkrRegistry`
- `SkrLooper` holds list of SKRs with activated CloudResources module and runs `SkrRunner` trough them
- `SkrManager` the controller-runtime manager.Manager implementation used to run Controllers
- `SkrRegistry` used to register Reconcilers we write and define their watches
- `SkrSource` the controller-runtime source.Source implementation that's not using Watch but only List() API methods

Referent implementation and usage example provided on the `CloudResourcesReconciler`

SKR handling is in this initial implementation timeout based (controllers running for a fixed time) but further improvements are predicted by observing the lens of queues and shutting down the manager once all queues are empty that will be done in subsequent PRs.

Had to fix the failing build in `components/kcp/pkg/provider/gcp/iprange/loadAddress.go`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
