### PR TITLE
skr manager stop on empty queue

### DIFF
--- a/components/kcp/pkg/skr/registry/registry.go
+++ b/components/kcp/pkg/skr/registry/registry.go
@@ -34,6 +34,9 @@ func (dl DescriptorList) AllQueuesEmpty() bool {
 			if !ok {
 				continue
 			}
+			if !src.IsStarted() {
+				return false
+			}
 			if src.Queue().Len() > 0 {
 				return false
 			}

--- a/components/kcp/pkg/skr/source/source.go
+++ b/components/kcp/pkg/skr/source/source.go
@@ -19,6 +19,7 @@ var _ SkrSource = &skrSource{}
 
 type SkrSource interface {
 	ctrlsource.Source
+	fmt.Stringer
 	IsStarted() bool
 	Queue() workqueue.RateLimitingInterface
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- added `SkrRunner.queueMonitor()` routine that will cancel Manager when all started source's queues are empty

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
