### PR TITLE
Adding patch API to FilestoreClient and some small fixes

### DIFF
--- a/components/kcp/pkg/provider/gcp/iprange/state.go
+++ b/components/kcp/pkg/provider/gcp/iprange/state.go
@@ -17,10 +17,11 @@ import (
 type State struct {
 	types.State
 
-	inSync    bool
-	ipAddress string
-	prefix    int
-	ipRanges  []string
+	inSync        bool
+	ipAddress     string
+	prefix        int
+	ipRanges      []string
+	projectNumber int64
 
 	addressOp    focal.OperationType
 	connectionOp focal.OperationType
@@ -70,15 +71,20 @@ func (f *stateFactory) NewState(ctx context.Context, ipRangeState types.State) (
 	if err != nil {
 		return nil, err
 	}
-
-	return newState(ipRangeState, snc, cc), nil
+	projectId := ipRangeState.Scope().Spec.Scope.Gcp.Project
+	projectNumber, err := gcpclient.GetCachedProjectNumber(ctx, projectId, httpClient)
+	if err != nil {
+		return nil, err
+	}
+	return newState(ipRangeState, snc, cc, projectNumber), nil
 }
 
-func newState(ipRangeState types.State, snc client.ServiceNetworkingClient, cc client.ComputeClient) *State {
+func newState(ipRangeState types.State, snc client.ServiceNetworkingClient, cc client.ComputeClient, projectNumber int64) *State {
 	return &State{
 		State:                   ipRangeState,
 		serviceNetworkingClient: snc,
 		computeClient:           cc,
+		projectNumber:           projectNumber,
 	}
 }
 

--- a/components/kcp/pkg/provider/gcp/iprange/syncPsaConnection.go
+++ b/components/kcp/pkg/provider/gcp/iprange/syncPsaConnection.go
@@ -33,7 +33,7 @@ func syncPsaConnection(ctx context.Context, st composed.State) (error, context.C
 			return composed.LogErrorAndReturn(err, "Error patching Service Connections in GCP", composed.StopWithRequeue, nil)
 		}
 	case focal.DELETE:
-		_, err := state.serviceNetworkingClient.DeleteServiceConnection(ctx, project, vpc)
+		_, err := state.serviceNetworkingClient.DeleteServiceConnection(ctx, state.projectNumber, vpc)
 		if err != nil {
 			state.AddErrorCondition(ctx, v1beta1.ReasonGcpError, err)
 			return composed.LogErrorAndReturn(err, "Error deleting Service Connections in GCP", composed.StopWithRequeue, nil)

--- a/components/kcp/pkg/provider/gcp/nfsinstance/client/filestoreClient.go
+++ b/components/kcp/pkg/provider/gcp/nfsinstance/client/filestoreClient.go
@@ -15,6 +15,7 @@ type FilestoreClient interface {
 	CreateFilestoreInstance(ctx context.Context, projectId, location, instanceId string, instance *file.Instance) (*file.Operation, error)
 	DeleteFilestoreInstance(ctx context.Context, projectId, location, instanceId string) (*file.Operation, error)
 	GetOperation(ctx context.Context, projectId, operationName string) (*file.Operation, error)
+	PatchFilestoreInstance(ctx context.Context, projectId, location, instanceId, updateMask string, instance *file.Instance) (*file.Operation, error)
 }
 
 func NewFilestoreClient() gcpclient.ClientProvider[FilestoreClient] {
@@ -71,6 +72,18 @@ func (c *filestoreClient) GetOperation(ctx context.Context, projectId, operation
 	operation, err := c.svcFilestore.Projects.Locations.Operations.Get(operationName).Do()
 	if err != nil {
 		logger.Error(err, "GetOperation", "projectId", projectId, "operationName", operationName)
+		return nil, err
+	}
+	return operation, nil
+}
+
+// PatchFilestoreInstance updates the Filestore instance.
+// UpdateMask is a comma-separated list of fully qualified names of fields that should be updated in this request.
+func (c *filestoreClient) PatchFilestoreInstance(ctx context.Context, projectId, location, instanceId, updateMask string, instance *file.Instance) (*file.Operation, error) {
+	logger := composed.LoggerFromCtx(ctx)
+	operation, err := c.svcFilestore.Projects.Locations.Instances.Patch(gcpclient.GetFilestoreInstancePath(projectId, location, instanceId), instance).UpdateMask(updateMask).Do()
+	if err != nil {
+		logger.Error(err, "PatchFilestoreInstance", "projectId", projectId, "location", location, "instanceId", instanceId)
 		return nil, err
 	}
 	return operation, nil


### PR DESCRIPTION

**FileStore Patch**

Changes proposed in this pull request:

- adding patch API to FilestoreClient
- getting the project number from cloud resource manager
- fixing the issue that delete network services connection doesn't work with project id and instead needs a project number