### PR TITLE
GCP NfsInstance Validations

### DIFF
--- a/components/kcp/api/cloud-control/v1beta1/nfsinstance_gcp_types.go
+++ b/components/kcp/api/cloud-control/v1beta1/nfsinstance_gcp_types.go
@@ -2,13 +2,16 @@ package v1beta1
 
 type NfsOptionsGcp struct {
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule=(self == oldSelf), message="Location is immutable."
 	Location string `json:"location"`
 
 	// +kubebuilder:default=BASIC_HDD
+	// +kubebuilder:validation:XValidation:rule=(self == oldSelf), message="Tier is immutable."
 	Tier GcpFileTier `json:"tier"`
 
 	// +kubebuilder:validation:Pattern="^[a-z][a-z0-9_]*[a-z0-9]$"
 	// +kubebuilder:default=vol1
+	// +kubebuilder:validation:XValidation:rule=(self == oldSelf), message="FileShareName is immutable."
 	FileShareName string `json:"fileShareName"`
 
 	// +kubebuilder:default=1024

--- a/components/kcp/api/cloud-control/v1beta1/nfsinstance_types.go
+++ b/components/kcp/api/cloud-control/v1beta1/nfsinstance_types.go
@@ -44,6 +44,7 @@ const (
 // NfsInstanceSpec defines the desired state of NfsInstance
 type NfsInstanceSpec struct {
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule=(self == oldSelf), message="RemoteRef is immutable."
 	RemoteRef RemoteRef `json:"remoteRef"`
 
 	// +kubebuilder:validation:Required

--- a/components/kcp/config/crd/bases/cloud-control.kyma-project.io_nfsinstances.yaml
+++ b/components/kcp/config/crd/bases/cloud-control.kyma-project.io_nfsinstances.yaml
@@ -70,8 +70,14 @@ spec:
                         default: vol1
                         pattern: ^[a-z][a-z0-9_]*[a-z0-9]$
                         type: string
+                        x-kubernetes-validations:
+                        - message: FileShareName is immutable.
+                          rule: (self == oldSelf)
                       location:
                         type: string
+                        x-kubernetes-validations:
+                        - message: Location is immutable.
+                          rule: (self == oldSelf)
                       tier:
                         default: BASIC_HDD
                         enum:
@@ -82,6 +88,9 @@ spec:
                         - ZONAL
                         - REGIONAL
                         type: string
+                        x-kubernetes-validations:
+                        - message: Tier is immutable.
+                          rule: (self == oldSelf)
                     required:
                     - capacityGb
                     - connectMode
@@ -107,6 +116,9 @@ spec:
                 - name
                 - namespace
                 type: object
+                x-kubernetes-validations:
+                - message: RemoteRef is immutable.
+                  rule: (self == oldSelf)
               scope:
                 properties:
                   name:

--- a/components/kcp/pkg/provider/gcp/iprange/compareStates.go
+++ b/components/kcp/pkg/provider/gcp/iprange/compareStates.go
@@ -60,11 +60,11 @@ func compareStates(ctx context.Context, st composed.State) (error, context.Conte
 			if state.serviceConnection == nil {
 				//If serviceConnection doesn't exist, add it.
 				state.connectionOp = client.ADD
-				state.ipRanges = []string{ipRange.Name}
+				state.ipRanges = []string{ipRange.Spec.RemoteRef.Name}
 			} else if index := state.doesConnectionIncludeRange(); index < 0 {
 				//If connection exists, but the ipRange is not part of it, include it.
 				state.connectionOp = client.MODIFY
-				state.ipRanges = append(state.serviceConnection.ReservedPeeringRanges, ipRange.Name)
+				state.ipRanges = append(state.serviceConnection.ReservedPeeringRanges, ipRange.Spec.RemoteRef.Name)
 			}
 		}
 

--- a/components/kcp/pkg/provider/gcp/iprange/loadAddress.go
+++ b/components/kcp/pkg/provider/gcp/iprange/loadAddress.go
@@ -21,8 +21,9 @@ func loadAddress(ctx context.Context, st composed.State) (error, context.Context
 	gcpScope := state.Scope().Spec.Scope.Gcp
 	project := gcpScope.Project
 	vpc := gcpScope.VpcNetwork
+	name := ipRange.Spec.RemoteRef.Name
 
-	addr, err := state.computeClient.GetIpRange(ctx, project, ipRange.Name)
+	addr, err := state.computeClient.GetIpRange(ctx, project, name)
 	if err != nil {
 
 		var e *googleapi.Error

--- a/components/kcp/pkg/provider/gcp/iprange/state.go
+++ b/components/kcp/pkg/provider/gcp/iprange/state.go
@@ -100,7 +100,7 @@ func (s State) doesConnectionIncludeRange() int {
 		return -1
 	}
 
-	rangeName := s.ObjAsIpRange().Name
+	rangeName := s.ObjAsIpRange().Spec.RemoteRef.Name
 	for i, name := range s.serviceConnection.ReservedPeeringRanges {
 		if rangeName == name {
 			return i

--- a/components/kcp/pkg/provider/gcp/iprange/syncAddress.go
+++ b/components/kcp/pkg/provider/gcp/iprange/syncAddress.go
@@ -20,18 +20,19 @@ func syncAddress(ctx context.Context, st composed.State) (error, context.Context
 	gcpScope := state.Scope().Spec.Scope.Gcp
 	project := gcpScope.Project
 	vpc := gcpScope.VpcNetwork
+	name := ipRange.Spec.RemoteRef.Name
 
 	var operation *compute.Operation
 	var err error
 	switch state.addressOp {
 	case client.ADD:
-		operation, err = state.computeClient.CreatePscIpRange(ctx, project, vpc, ipRange.Name, ipRange.Name, state.ipAddress, int64(state.prefix))
+		operation, err = state.computeClient.CreatePscIpRange(ctx, project, vpc, name, name, state.ipAddress, int64(state.prefix))
 	case client.MODIFY:
 		err = errors.New("IpRange update not supported.")
 		state.AddErrorCondition(ctx, v1beta1.ReasonNotSupported, err)
 		return composed.LogErrorAndReturn(err, "IpRange update not supported.", composed.StopAndForget, nil)
 	case client.DELETE:
-		operation, err = state.computeClient.DeleteIpRange(ctx, project, ipRange.Name)
+		operation, err = state.computeClient.DeleteIpRange(ctx, project, name)
 	}
 
 	if err != nil {

--- a/components/kcp/pkg/provider/gcp/nfsinstance/state.go
+++ b/components/kcp/pkg/provider/gcp/nfsinstance/state.go
@@ -84,14 +84,6 @@ func (s State) toInstance() *file.Instance {
 	project := gcpScope.Project
 	vpc := gcpScope.VpcNetwork
 
-	nwConfig := &file.NetworkConfig{
-		Network:     gcpclient.GetVPCPath(project, vpc),
-		ConnectMode: string(gcpOptions.ConnectMode),
-	}
-	if s.IpRange() != nil {
-		nwConfig.ReservedIpRange = s.IpRange().Spec.Cidr
-	}
-
 	return &file.Instance{
 		Description: nfsInstance.Name,
 		Tier:        string(gcpOptions.Tier),
@@ -103,7 +95,11 @@ func (s State) toInstance() *file.Instance {
 			},
 		},
 		Networks: []*file.NetworkConfig{
-			nwConfig,
+			{
+				Network:         gcpclient.GetVPCPath(project, vpc),
+				ConnectMode:     string(gcpOptions.ConnectMode),
+				ReservedIpRange: s.IpRange().Spec.RemoteRef.Name,
+			},
 		},
 	}
 }

--- a/components/kcp/pkg/provider/gcp/nfsinstance/validateAlways.go
+++ b/components/kcp/pkg/provider/gcp/nfsinstance/validateAlways.go
@@ -13,8 +13,8 @@ func validateAlways(ctx context.Context, st composed.State) (error, context.Cont
 	state := st.(*State)
 	logger := composed.LoggerFromCtx(ctx)
 
-	//If the instance already exists, continue.
-	if state.fsInstance != nil {
+	//If the instance already exists or if it is deleting, continue to next action.
+	if state.fsInstance != nil || composed.MarkedForDeletionPredicate(ctx, st) {
 		return nil, nil
 	}
 
@@ -26,15 +26,6 @@ func validateAlways(ctx context.Context, st composed.State) (error, context.Cont
 
 	//Validate whether the requested capacity is a valid value.
 	if _, err := IsValidCapacity(gcpOptions.Tier, gcpOptions.CapacityGb); err != nil {
-		state.validations = append(state.validations, err.Error())
-	}
-
-	//Validate whether the nwMask is a valid value.
-	cidr := ""
-	if state.IpRange() != nil {
-		cidr = state.IpRange().Spec.Cidr
-	}
-	if _, err := IsValidNwMask(gcpOptions.Tier, cidr); err != nil {
 		state.validations = append(state.validations, err.Error())
 	}
 

--- a/components/kcp/pkg/provider/gcp/nfsinstance/validations.go
+++ b/components/kcp/pkg/provider/gcp/nfsinstance/validations.go
@@ -2,17 +2,9 @@ package nfsinstance
 
 import (
 	"errors"
-	"fmt"
-	"strings"
 
 	"github.com/kyma-project/cloud-manager/components/kcp/api/cloud-control/v1beta1"
 )
-
-type GcpFileTierValidation interface {
-	IsValidCapacity(capacityGb int) (bool, error)
-	CanScaleDown() bool
-	IsValidNwMask(cidr string) (bool, error)
-}
 
 func IsValidCapacity(tier v1beta1.GcpFileTier, capacityGb int) (bool, error) {
 	switch tier {
@@ -53,29 +45,4 @@ func IsValidCapacity(tier v1beta1.GcpFileTier, capacityGb int) (bool, error) {
 func CanScaleDown(tier v1beta1.GcpFileTier) bool {
 	return tier == v1beta1.ZONAL || tier == v1beta1.HIGH_SCALE_SSD ||
 		tier == v1beta1.ENTERPRISE || tier == v1beta1.REGIONAL
-}
-
-func IsValidNwMask(tier v1beta1.GcpFileTier, cidr string) (bool, error) {
-	if cidr == "" {
-		return true, nil
-	}
-	switch tier {
-	case v1beta1.BASIC_HDD, v1beta1.STANDARD, v1beta1.BASIC_SSD, v1beta1.PREMIUM, v1beta1.ZONAL:
-		return checkCidrSuffix(tier, cidr, "/29")
-	case v1beta1.ENTERPRISE, v1beta1.REGIONAL:
-		return checkCidrSuffix(tier, cidr, "/26")
-	case v1beta1.HIGH_SCALE_SSD:
-		return checkCidrSuffix(tier, cidr, "/24")
-	default:
-		return false, errors.New("Unknown Tier")
-	}
-}
-
-func checkCidrSuffix(tier v1beta1.GcpFileTier, cidr, suffix string) (bool, error) {
-	valid := strings.HasSuffix(cidr, suffix)
-	if valid {
-		return valid, nil
-	} else {
-		return valid, errors.New(fmt.Sprintf("CIDR block should be %s for Tier: %s", suffix, string(tier)))
-	}
 }


### PR DESCRIPTION
**Description**

Updated GCP NfsInstance Validations.
Used IpRangeName instead of CIDR while creating NfsInstance

**Related issue(s)**
NA