### PR TITLE
Fixes ignoring go.mod in system temp root /tmp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.21 as builder
 ARG TARGETOS
 ARG TARGETARCH
 
-WORKDIR /tmp
+WORKDIR /src
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -28,7 +28,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /tmp/manager .
+COPY --from=builder /src/manager .
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fixes failing image build as go is ignoring go.mod in system temp root /tmp