### PR TITLE
Updates github actions to remove Node.js 16 deprecation warning.

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '1.21'
       - name: Display Go version


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Updates GitHub actions to remove Node.js 16 deprecation warning.